### PR TITLE
version updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 plugins
 {
-	id 'org.springframework.boot' version '2.7.0' 
-	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id 'org.springframework.boot' version '3.5.14'
+	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 	id 'eclipse'
 	id 'idea'
 	id 'war'
-	id 'maven-publish'
 }
 
 group = 'com.ibm.cicsdev.springboot'
@@ -15,16 +14,16 @@ version = '0.1.0'
 
 
 // If in Eclipse, add Javadoc to the local project classpath
-eclipse 
+eclipse
 {
-    classpath 
+    classpath
     {
         downloadJavadoc = true
     }
 }
 
 
-repositories 
+repositories
 {
     mavenCentral()
 }
@@ -35,12 +34,10 @@ java
     toolchain
     {
         languageVersion = JavaLanguageVersion.of(java_version)
-        vendor = JvmVendorSpec.IBM
-        implementation = JvmImplementation.J9
     }
 }
 
-dependencies 
+dependencies
 {
     // Spring Boot web starter dependency
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -54,37 +51,9 @@ dependencies
     // Don't include TomCat in the runtime build, but do put it in WEB-INF so it can be run standalone as well as embedded
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
   
-    // CICS TS V5.5 Maven BOM (as of 19th May 2020)
-    compileOnly enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:5.5-20200519131930-PH25409")
+    // CICS BOM (as of Sept 2024)
+    compileOnly enforcedPlatform('com.ibm.cics:com.ibm.cics.ts.bom:6.1-20250812133513-PH63856')
       
     // Don't include JCICS in the final build (no need for version because we have BOM)
-    compileOnly("com.ibm.cics:com.ibm.cics.server")                 
-}
-
-
-publishing {
-    publications {
-    	// Publication for JCICS
-        maven(MavenPublication) {
-            groupId "${group}"
-            version "${version}"
-            artifactId "${archivesBaseName}" 
-            artifact bootWar
-        }
-    }
-    
-    // Configure the Maven repository to publish to somewhere which is configurable
-    // with environment variables from outside gradle.
-    //
-    // For example:
-    //   gradle build publish \
-    //   -Ppublish_repo_releases_url="file://my-folder" \
-    //   -Ppublish_repo_releases_name="my-maven-repo"
-    //
-    repositories {
-        maven {
-            url = "${publish_repo_releases_url}/${publish_repo_releases_name}"
-        }
-    }
-
+    compileOnly("com.ibm.cics:com.ibm.cics.server")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,19 @@
 #
-# Values in this file provide defaults to variables used in the 
+# Values in this file provide defaults to variables used in the
 # gradle files.
 #
 
-# Normally we don't publish any built artifacts to a repository.
-# But if we do, these are the default values we use to indicate
-# where the files should be placed.
-#
-# These can be over-ridden from the command line 
-# with -Ppublish_repo_releases_url="file://my-folder" for example.
-# 
-# These values only have any effect if the publish goal is used.
-# For example: gradle build publish.
-publish_repo_releases_url = 'default-value-for-publish_repo_releases_url'
-publish_repo_releases_name = 'default-value-for-publish_repo_releases_name'
-java_version = 8
+# Centralized Java version for Gradle toolchain and Maven compiler
+java_version = 17
+
+# Gradle daemon and parallel builds for better performance
+org.gradle.daemon=true
+org.gradle.parallel=true
+
+# Enable toolchain auto-provisioning to download JDKs if not found locally
+# This allows builds to work on systems without the specific Java version installed
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true
+
+# Configuration cache disabled due to CICS Bundle Plugin compatibility
+# org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project 
+<project
   xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -8,7 +8,8 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>3.5.14</version>
+    <relativePath/>
   </parent>
   
   <!-- Application properties -->
@@ -16,22 +17,22 @@
   <artifactId>cics-java-liberty-springboot-security</artifactId>
   <version>0.1.0</version>
   <name>cics-java-liberty-springboot-security</name>
-  <description>Spring Boot Web Secure Sample with Java EE pre-authentication</description>
+  <description>Spring Boot Web Secure Sample with Jakarta EE pre-authentication</description>
   <properties>
-    <java.version>1.8</java.version>
-
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
   </properties>
 
-  <!-- CICS TS V5.5 BOM (as of May 2020) -->
+  <!-- Dependency Management -->
   <dependencyManagement>
     <dependencies>
+      <!-- CICS TS V6.1 BOM (as of Sept 2024) -->
       <dependency>
         <groupId>com.ibm.cics</groupId>
         <artifactId>com.ibm.cics.ts.bom</artifactId>
-        <version>5.5-20200519131930-PH25409</version>
+        <version>6.1-20250812133513-PH63856</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -79,28 +80,14 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-	
-
-    <!-- 
-    Publishes artifacts to here if the deploy goal is used. 
-
-    The values here can be passed on the maven command line
-    using the -D flag syntax 
-  
-    for example:
-    -Dpublish_repo_snapshots_name=my-repo 
-    -->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>${publish_repo_snapshots_name}</id>
-            <url>${publish_repo_snapshots_url}</url>
-        </snapshotRepository>
-        <repository>
-            <id>${publish_repo_releases_name}</id>
-            <url>${publish_repo_releases_url}</url>
-        </repository>
-    </distributionManagement>
 
 </project>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,8 @@
+// ============================================================================
+// Root Project Configuration
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+}
+
+// ============================================================================
 rootProject.name = 'com.ibm.cicsdev.springboot.security'

--- a/src/main/java/com/ibm/cicsdev/springboot/security/Application.java
+++ b/src/main/java/com/ibm/cicsdev/springboot/security/Application.java
@@ -13,17 +13,18 @@ package com.ibm.cicsdev.springboot.security;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
-public class Application implements WebMvcConfigurer 
+public class Application implements WebMvcConfigurer
 {
-	public static void main(String[] args) 
+	public static void main(String[] args)
 	{
 		SpringApplication.run(Application.class, args);
 	}
@@ -33,9 +34,9 @@ public class Application implements WebMvcConfigurer
 	 * @param registry
 	 */
 	@Override
-	public void addViewControllers(ViewControllerRegistry registry) 
+	public void addViewControllers(ViewControllerRegistry registry)
 	{
-		// Register our login page (found in the resources/templates folder) as a ViewController 
+		// Register our login page (found in the resources/templates folder) as a ViewController
 		// The template 'login' HTML uses the Thymeleaf template engine for simplicity and convenience
 		registry.addViewController("/login").setViewName("login");
 	}
@@ -44,20 +45,22 @@ public class Application implements WebMvcConfigurer
 	/** This class allows you to override the default Web Security configuration */
 	@EnableWebSecurity(debug = false)
 	@Configuration
-	protected static class ApplicationSecurity extends WebSecurityConfigurerAdapter 
+	protected static class ApplicationSecurity
 	{
-		@Override
-		protected void configure(HttpSecurity http) throws Exception 
+		@Bean
+		public SecurityFilterChain filterChain(HttpSecurity http) throws Exception
 		{
 			http
-				.csrf().disable()
-				.authorizeRequests()
+				.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(authz -> authz
 				        // Allow access to URLs required for form login
-				        .antMatchers("/login", "/resources/**", "/j_security_check","css/**").permitAll()
+				        .requestMatchers("/login", "/resources/**", "/j_security_check","css/**").permitAll()
 						.anyRequest().authenticated()
-						.and()
-				// Use Java EE pre-authentication and map these roles to Spring Security		
-				.jee().mappableRoles("USER", "ADMIN");
+				)
+				// Use Jakarta EE pre-authentication and map these roles to Spring Security
+				.jee(jee -> jee.mappableRoles("USER", "ADMIN"));
+			
+			return http.build();
 		}
 	}
 }

--- a/src/main/java/com/ibm/cicsdev/springboot/security/Application.java
+++ b/src/main/java/com/ibm/cicsdev/springboot/security/Application.java
@@ -51,7 +51,6 @@ public class Application implements WebMvcConfigurer
 		public SecurityFilterChain filterChain(HttpSecurity http) throws Exception
 		{
 			http
-				.csrf(csrf -> csrf.disable())
 				.authorizeHttpRequests(authz -> authz
 				        // Allow access to URLs required for form login
 				        .requestMatchers("/login", "/resources/**", "/j_security_check","css/**").permitAll()


### PR DESCRIPTION
- Updated Spring Boot from 2.7.0 to 3.5.14
- Updated Java version from 8 to 17
- Updated CICS BOM to 6.1-20250812133513-PH63856 (as of Sept 2024)
- Migrated Spring Security from 5 to 6 (WebSecurityConfigurerAdapter to SecurityFilterChain)
- Updated Gradle wrapper from 7.5 to 8.14.4
- Added foojay resolver plugin for JDK auto-provisioning
- Updated dependency-management plugin to 1.1.7
- Configured Gradle toolchain with auto-download support
- Updated Maven compiler plugin to use release parameter
- Changed antMatchers() to requestMatchers() for Spring Security 6
- Removed vendor-specific toolchain restrictions
- Removed publishing and distributionManagement configurations